### PR TITLE
Add ability to disable routes in vanilla config.php.

### DIFF
--- a/library/class.apiengine.php
+++ b/library/class.apiengine.php
@@ -195,9 +195,12 @@ final class APIEngine {
       // Register all endpoints in the router
       foreach ($endpoints as $method => $endpoints) {
         foreach ($endpoints as $endpoint => $data) {
-          $endpoint = "/" . $resource . rtrim($endpoint, "/");
 
-          $router->map($method, $endpoint, $data);
+          $endpoint = "/" . $resource . rtrim($endpoint, "/");
+          // Check if route is enabled
+          if (!c("API.DisabledRoutes.".strtoupper($method).' '.$endpoint)) {
+            $router->map($method, $endpoint, $data);
+          }
         }
       }
 

--- a/library/class.apiengine.php
+++ b/library/class.apiengine.php
@@ -195,10 +195,10 @@ final class APIEngine {
       // Register all endpoints in the router
       foreach ($endpoints as $method => $endpoints) {
         foreach ($endpoints as $endpoint => $data) {
-
           $endpoint = "/" . $resource . rtrim($endpoint, "/");
+          
           // Check if route is enabled
-          if (!c("API.DisabledRoutes.".strtoupper($method).' '.$endpoint)) {
+          if (!c("API.DisabledRoutes.".strtoupper($method).".".$endpoint)) {
             $router->map($method, $endpoint, $data);
           }
         }


### PR DESCRIPTION
I’ve added a feature that allow to disable routes in vanilla config.php.
It is very simple and rudimentary. If the route is disabled it throws a 405 not allowed error.

**Syntax:**

`$Configuration['API']['DisabledRoutes'][':method'][':endPoint'] = TRUE;`

For example if I want to disable `GET /users`

`$Configuration['API']['DisabledRoutes']['GET']['/users'] = TRUE;`


**The :endPoint parameter have to match exactly it definition:**

For example with `GET /users/:id` endpoint:

The definition of the endpoint is:

`static::get("/[i:UserID]")`

The syntax to disable it is:

`$Configuration['API']['DisabledRoutes']['GET']['/users/[i:UserID]'] = TRUE;`